### PR TITLE
Frigo→Dispensa rename, storico in profilo, recipe improvements, PDF e…

### DIFF
--- a/app.js
+++ b/app.js
@@ -571,7 +571,23 @@ function confirmAddFridge() {
   closeAddFridgeModal();
   renderFridge();
   renderFridge('pianoFridgeContent');
-  showToast('✅ ' + name + ' aggiunto al frigo', 'success');
+  showToast('✅ ' + name + ' aggiunto alla dispensa', 'success');
+}
+
+/* Aggiunge un ingrediente acquistato alla dispensa (chiamato da spesa.js) */
+function addFromSpesa(name, qty, unit) {
+  if (!name || isNaN(qty) || qty <= 0) return;
+  if (!pantryItems) pantryItems = {};
+  var existing = pantryItems[name] || {};
+  pantryItems[name] = Object.assign({}, existing, {
+    quantity: (existing.quantity || 0) + qty,
+    unit:     unit || existing.unit || 'g',
+    category: existing.category || '🧂 Altro',
+    icon:     existing.icon || (typeof getCategoryIcon === 'function' ? getCategoryIcon(existing.category || '🧂 Altro') : '🧂')
+  });
+  if (typeof saveData === 'function') saveData();
+  if (typeof renderFridge === 'function') renderFridge();
+  if (typeof showToast === 'function') showToast('🛒 ' + name + ': ' + qty + ' ' + (unit || 'g') + ' → dispensa', 'success');
 }
 
 function saveFridgeConfig() {
@@ -596,7 +612,7 @@ function confirmSaveFridge() {
   });
   localStorage.setItem('nutriplanFridgeConfigs', JSON.stringify(configs));
   closeSaveFridgeModal();
-  showToast('💾 Frigo "' + name + '" salvato', 'success');
+  showToast('💾 Dispensa "' + name + '" salvata', 'success');
 }
 
 function renderSavedFridgeList(container) {
@@ -629,7 +645,7 @@ function loadFridgeConfig(id) {
   if (typeof saveData === 'function') saveData();
   closeSavedFridgeModal();
   renderFridge();
-  showToast('📁 Frigo "' + cfg.name + '" caricato', 'success');
+  showToast('📁 Dispensa "' + cfg.name + '" caricata', 'success');
 }
 
 function deleteFridgeConfig(id) {
@@ -647,7 +663,7 @@ function deleteFridgeConfig(id) {
 ══════════════════════════════════════════════════ */
 function updateAllUI() {
   if (typeof renderPiano   === 'function') renderPiano();
-  if (typeof renderFridge  === 'function' && currentPage === 'pantry') renderFridge();
+  if (typeof renderFridge  === 'function' && currentPage === 'dispensa') renderFridge();
   if (typeof renderRicette === 'function' && currentPage === 'ricette') renderRicette();
   if (typeof renderSpesa   === 'function' && currentPage === 'spesa') renderSpesa();
   if (typeof renderStats   === 'function' && currentPage === 'stats') renderStats();
@@ -789,9 +805,8 @@ function goToPage(key) {
   /* Render specifico per pagina */
   var renders = {
     'piano':       function() { if (typeof renderPiano   === 'function') renderPiano(); },
-    'frigo':       function() { if (typeof renderFridge  === 'function') renderFridge(); },
+    'dispensa':    function() { if (typeof renderFridge  === 'function') renderFridge(); },
     'ricette':     function() { if (typeof renderRicette === 'function') renderRicette(); },
-    'storico':     function() { if (typeof renderStorico === 'function') renderStorico(); },
     'spesa':       function() { if (typeof renderSpesa   === 'function') renderSpesa(); },
     'statistiche': function() { if (typeof renderStats   === 'function') renderStats(); },
     'profilo':     function() { if (typeof renderProfilo === 'function') renderProfilo(); }
@@ -817,9 +832,6 @@ function switchPianoTab(tabKey, el) {
   if (tabKey === 'piano') {
     if (typeof renderMealItems    === 'function') renderMealItems();
     if (typeof renderPianoRicette === 'function') renderPianoRicette();
-  }
-  if (tabKey === 'frigo') {
-    if (typeof renderFridge === 'function') renderFridge('pianoFridgeContent');
   }
 }
 

--- a/components.css
+++ b/components.css
@@ -828,3 +828,90 @@
 .auth-divider::after { content: ''; flex: 1; height: 1px; background: var(--border); }
 .auth-switch { text-align: center; font-size: .8rem; color: var(--text-light); margin-top: 18px; }
 .auth-switch a { font-weight: 700; }
+
+/* ══════════════════════════════════════════════════
+   27. RECIPE MODAL  (.rm-*)
+══════════════════════════════════════════════════ */
+.rm-hero {
+  display: flex; align-items: center; gap: 14px;
+  padding: 18px 20px 16px;
+  border-bottom: 1.5px solid var(--border);
+  background: color-mix(in srgb, var(--mc, var(--primary)) 6%, var(--bg-card));
+}
+.rm-hero-icon {
+  width: 52px; height: 52px; flex-shrink: 0;
+  border-radius: var(--r-lg);
+  background: color-mix(in srgb, var(--mc, var(--primary)) 14%, var(--bg-card));
+  border: 2px solid color-mix(in srgb, var(--mc, var(--primary)) 30%, transparent);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 1.8rem;
+}
+.rm-hero-name {
+  font-size: 1.08rem; font-weight: 800; line-height: 1.2;
+  color: var(--text-1);
+}
+.rm-hero-pasto {
+  font-size: .78rem; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .06em; margin-top: 3px;
+}
+.rm-avail {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 20px;
+  font-size: .8rem; color: var(--text-2);
+  border-bottom: 1px solid var(--border);
+}
+.rm-avail-track {
+  flex: 1; height: 6px; background: var(--bg-subtle);
+  border-radius: 99px; overflow: hidden;
+}
+.rm-avail-fill {
+  height: 100%; border-radius: 99px;
+  transition: width .4s ease;
+}
+.rm-section-label {
+  font-size: .68rem; font-weight: 800; text-transform: uppercase;
+  letter-spacing: .09em; color: var(--text-light);
+  padding: 14px 20px 6px;
+}
+.rm-ing-list {
+  list-style: none; padding: 0 20px 4px; margin: 0;
+  display: flex; flex-direction: column; gap: 5px;
+}
+.rm-ing {
+  display: flex; align-items: center; gap: 10px;
+  padding: 7px 10px; border-radius: var(--r-sm);
+  background: var(--bg-subtle);
+  font-size: .85rem; font-weight: 500;
+}
+.rm-ing.ok {
+  background: color-mix(in srgb, #22c55e 8%, var(--bg-subtle));
+}
+.rm-check {
+  width: 18px; height: 18px; flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--border-mid);
+  display: flex; align-items: center; justify-content: center;
+  font-size: .65rem; color: var(--bg-card);
+  font-weight: 900;
+}
+.rm-ing.ok .rm-check {
+  background: var(--success, #22c55e);
+}
+.rm-qty {
+  margin-left: auto; font-size: .72rem;
+  color: var(--text-light); font-weight: 700; white-space: nowrap;
+}
+.rm-steps {
+  padding: 0 20px 8px 36px; margin: 0;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.rm-steps li {
+  font-size: .87rem; line-height: 1.5; color: var(--text-2);
+  padding: 6px 0; border-bottom: 1px dashed var(--border);
+}
+.rm-steps li:last-child { border-bottom: none; }
+.rm-prep {
+  padding: 4px 20px 12px;
+  font-size: .87rem; line-height: 1.6; color: var(--text-2);
+  white-space: pre-wrap;
+}

--- a/index.html
+++ b/index.html
@@ -77,9 +77,9 @@
     <span class="nav-icon">🏠</span>
     <span class="nav-label">Piano</span>
   </button>
-  <button class="nav-tab" id="st-frigo" onclick="goToPage('frigo')">
-    <span class="nav-icon">❄️</span>
-    <span class="nav-label">Frigo</span>
+  <button class="nav-tab" id="st-dispensa" onclick="goToPage('dispensa')">
+    <span class="nav-icon">🗄️</span>
+    <span class="nav-label">Dispensa</span>
   </button>
   <button class="nav-tab" id="st-ricette" onclick="goToPage('ricette')">
     <span class="nav-icon">📖</span>
@@ -88,10 +88,6 @@
 
   <span class="sidebar-section-label">Gestione</span>
 
-  <button class="nav-tab" id="st-storico" onclick="goToPage('storico')">
-    <span class="nav-icon">📅</span>
-    <span class="nav-label">Storico</span>
-  </button>
   <button class="nav-tab" id="st-spesa" onclick="goToPage('spesa')">
     <span class="nav-icon">🛒</span>
     <span class="nav-label">Spesa</span>
@@ -124,81 +120,61 @@
       </div>
     </div>
 
-    <!-- Tab selettore interno — solo 2 tab -->
-    <div class="page-tabs">
-      <button class="page-tab active" onclick="switchPianoTab('piano',this)">🍽 Piano</button>
-      <button class="page-tab" onclick="switchPianoTab('frigo',this)">❄️ Frigo</button>
+    <!-- Contenuto diretto (nessun sub-tab) -->
+    <div class="meals-done-bar">
+      <span class="meals-done-icon">🍽</span>
+      <div class="meals-done-info">
+        <div class="meals-done-label">Pasti completati oggi</div>
+        <div class="meals-done-dots" id="mealsDoneDots"></div>
+      </div>
+      <span class="meals-done-count" id="mealsDoneCount">0 / 5</span>
     </div>
 
-    <!-- Tab: Piano (ingredienti nel piano + ricette per pasto selezionato) -->
-    <div class="page-tab-content active" id="tab-piano">
-
-      <div class="meals-done-bar">
-        <span class="meals-done-icon">🍽</span>
-        <div class="meals-done-info">
-          <div class="meals-done-label">Pasti completati oggi</div>
-          <div class="meals-done-dots" id="mealsDoneDots"></div>
-        </div>
-        <span class="meals-done-count" id="mealsDoneCount">0 / 5</span>
-      </div>
-
-      <div class="meal-selector" id="mealSelector">
-        <button class="meal-btn active" onclick="selectMeal('colazione',this)">
-          <span class="meal-btn-icon">☀️</span>
-          <span class="meal-btn-label">Colazione</span>
-          <span class="meal-btn-count" id="cnt-colazione">0</span>
-        </button>
-        <button class="meal-btn" onclick="selectMeal('spuntino',this)">
-          <span class="meal-btn-icon">🍎</span>
-          <span class="meal-btn-label">Spuntino</span>
-          <span class="meal-btn-count" id="cnt-spuntino">0</span>
-        </button>
-        <button class="meal-btn" onclick="selectMeal('pranzo',this)">
-          <span class="meal-btn-icon">🍽</span>
-          <span class="meal-btn-label">Pranzo</span>
-          <span class="meal-btn-count" id="cnt-pranzo">0</span>
-        </button>
-        <button class="meal-btn" onclick="selectMeal('merenda',this)">
-          <span class="meal-btn-icon">🥪</span>
-          <span class="meal-btn-label">Merenda</span>
-          <span class="meal-btn-count" id="cnt-merenda">0</span>
-        </button>
-        <button class="meal-btn" onclick="selectMeal('cena',this)">
-          <span class="meal-btn-icon">🌙</span>
-          <span class="meal-btn-label">Cena</span>
-          <span class="meal-btn-count" id="cnt-cena">0</span>
-        </button>
-      </div>
-
-      <div id="mealProgressWrap"></div>
-
-      <!-- Ingredienti del piano per il pasto selezionato -->
-      <div class="piano-section-label">🌿 Ingredienti nel piano</div>
-      <div id="mealItemsWrap" class="meal-items-list"></div>
-
-      <!-- Ricette per il pasto selezionato -->
-      <div class="piano-section-label">📖 Ricette</div>
-      <div id="pianoRicetteWrap"></div>
-
+    <div class="meal-selector" id="mealSelector">
+      <button class="meal-btn active" onclick="selectMeal('colazione',this)">
+        <span class="meal-btn-icon">☀️</span>
+        <span class="meal-btn-label">Colazione</span>
+        <span class="meal-btn-count" id="cnt-colazione">0</span>
+      </button>
+      <button class="meal-btn" onclick="selectMeal('spuntino',this)">
+        <span class="meal-btn-icon">🍎</span>
+        <span class="meal-btn-label">Spuntino</span>
+        <span class="meal-btn-count" id="cnt-spuntino">0</span>
+      </button>
+      <button class="meal-btn" onclick="selectMeal('pranzo',this)">
+        <span class="meal-btn-icon">🍽</span>
+        <span class="meal-btn-label">Pranzo</span>
+        <span class="meal-btn-count" id="cnt-pranzo">0</span>
+      </button>
+      <button class="meal-btn" onclick="selectMeal('merenda',this)">
+        <span class="meal-btn-icon">🥪</span>
+        <span class="meal-btn-label">Merenda</span>
+        <span class="meal-btn-count" id="cnt-merenda">0</span>
+      </button>
+      <button class="meal-btn" onclick="selectMeal('cena',this)">
+        <span class="meal-btn-icon">🌙</span>
+        <span class="meal-btn-label">Cena</span>
+        <span class="meal-btn-count" id="cnt-cena">0</span>
+      </button>
     </div>
 
-    <!-- Tab: Frigo (contenuto del frigo) -->
-    <div class="page-tab-content" id="tab-frigo">
-      <div style="display:flex;gap:8px;justify-content:flex-end;margin-bottom:12px;">
-        <button class="btn btn-secondary btn-small" onclick="saveFridgeConfig()">💾 Salva</button>
-        <button class="btn btn-secondary btn-small" onclick="openSavedFridges()">📁 Salvati</button>
-        <button class="btn btn-primary btn-small" onclick="openAddFridge()">➕ Aggiungi</button>
-      </div>
-      <div id="pianoFridgeContent"></div>
-    </div>
+    <div id="mealProgressWrap"></div>
+
+    <!-- Ingredienti del piano per il pasto selezionato -->
+    <div class="piano-section-label">🌿 Ingredienti nel piano</div>
+    <div id="mealItemsWrap" class="meal-items-list"></div>
+
+    <!-- Ricette per il pasto selezionato -->
+    <div class="piano-section-label">📖 Ricette</div>
+    <div id="pianoRicetteWrap"></div>
 
   </div>
 
-  <!-- ── FRIGO ────────────────────────────────────── -->
-  <div class="page" id="page-frigo">
+  <!-- ── DISPENSA ─────────────────────────────────── -->
+  <div class="page" id="page-dispensa">
     <div class="page-header">
       <div>
-        <div class="page-header-title">❄️ Frigo</div>
+        <div class="page-header-title">🗄️ Dispensa</div>
         <div class="page-header-sub">Ingredienti disponibili</div>
       </div>
       <div class="page-header-actions">
@@ -251,17 +227,6 @@
     </div>
   </div>
 
-  <!-- ── STORICO ──────────────────────────────────── -->
-  <div class="page" id="page-storico">
-    <div class="page-header">
-      <div>
-        <div class="page-header-title">📅 Storico pasti</div>
-        <div class="page-header-sub">Cronologia alimentare</div>
-      </div>
-    </div>
-    <div id="storicoContent"></div>
-  </div>
-
   <!-- ── SPESA ────────────────────────────────────── -->
   <div class="page" id="page-spesa">
     <div class="page-header">
@@ -295,6 +260,9 @@
         <div class="page-header-title">👤 Profilo</div>
         <div class="page-header-sub">Impostazioni e piano personale</div>
       </div>
+      <div class="page-header-actions">
+        <button class="btn btn-secondary btn-small" onclick="exportPDF()">📄 PDF</button>
+      </div>
     </div>
     <div id="profiloPage"></div>
   </div>
@@ -310,17 +278,13 @@
       <span class="nav-icon">🏠</span>
       <span class="nav-label">Piano</span>
     </button>
-    <button class="nav-tab" id="bn-frigo" onclick="goToPage('frigo')">
-      <span class="nav-icon">❄️</span>
-      <span class="nav-label">Frigo</span>
+    <button class="nav-tab" id="bn-dispensa" onclick="goToPage('dispensa')">
+      <span class="nav-icon">🗄️</span>
+      <span class="nav-label">Dispensa</span>
     </button>
     <button class="nav-tab" id="bn-ricette" onclick="goToPage('ricette')">
       <span class="nav-icon">📖</span>
       <span class="nav-label">Ricette</span>
-    </button>
-    <button class="nav-tab" id="bn-storico" onclick="goToPage('storico')">
-      <span class="nav-icon">📅</span>
-      <span class="nav-label">Storico</span>
     </button>
     <button class="nav-tab" id="bn-spesa" onclick="goToPage('spesa')">
       <span class="nav-icon">🛒</span>
@@ -357,12 +321,12 @@
   </div>
 </div>
 
-<!-- Modale: salva frigo -->
+<!-- Modale: salva dispensa -->
 <div class="modal" id="saveFridgeModal">
   <div class="modal-box">
     <div class="modal-handle"></div>
     <div class="modal-header">
-      <h2 class="modal-title">💾 Salva frigo</h2>
+      <h2 class="modal-title">💾 Salva dispensa</h2>
       <button class="modal-close" onclick="closeSaveFridgeModal()">✕</button>
     </div>
     <div class="modal-body">
@@ -399,7 +363,7 @@
   <div class="modal-box">
     <div class="modal-handle"></div>
     <div class="modal-header">
-      <h2 class="modal-title">➕ Aggiungi al frigo</h2>
+      <h2 class="modal-title">➕ Aggiungi alla dispensa</h2>
       <button class="modal-close" onclick="closeAddFridge()">✕</button>
     </div>
     <div class="modal-body">
@@ -549,7 +513,7 @@
     </div>
     <div class="modal-body">
       <p class="text-light text-sm mb-12">
-        Inserisci la quantità acquistata per aggiornare il frigo automaticamente.
+        Inserisci la quantità acquistata per aggiornare la dispensa automaticamente.
       </p>
       <div class="qty-modal-wrap">
         <input type="number" id="purchasedQtyInput" min="0" step="any" placeholder="0"

--- a/pdf.js
+++ b/pdf.js
@@ -1,92 +1,128 @@
 function exportPDF() {
-    var MEAL_LABELS = {
-        colazione: 'Colazione', spuntino: 'Spuntino',
-        pranzo: 'Pranzo', merenda: 'Merenda', cena: 'Cena'
-    };
-    var MEALS_ORDER = ['colazione', 'spuntino', 'pranzo', 'merenda', 'cena'];
+  var MEAL_LABELS  = { colazione:'Colazione', spuntino:'Spuntino', pranzo:'Pranzo', merenda:'Merenda', cena:'Cena' };
+  var MEALS_ORDER  = ['colazione','spuntino','pranzo','merenda','cena'];
+  var DAYS_IT      = ['Dom','Lun','Mar','Mer','Gio','Ven','Sab'];
+  var MONTHS_IT    = ['Gen','Feb','Mar','Apr','Mag','Giu','Lug','Ago','Set','Ott','Nov','Dic'];
+  var today        = new Date();
+  var todayLabel   = DAYS_IT[today.getDay()]+' '+today.getDate()+' '+MONTHS_IT[today.getMonth()]+' '+today.getFullYear();
 
-    var lines = [];
-    lines.push('NutriPlan — Piano Alimentare');
-    lines.push('Esportato il: ' + new Date().toLocaleString('it-IT'));
-    lines.push('');
-    lines.push('═══════════════════════════════════');
-    lines.push('');
-
-    // Piano giornaliero
-    lines.push('PIANO ALIMENTARE GIORNALIERO');
-    lines.push('');
-    MEALS_ORDER.forEach(function (meal) {
-        var items = (mealPlan[meal] && mealPlan[meal].principale) || [];
-        if (!items.length) return;
-        lines.push('▸ ' + (MEAL_LABELS[meal] || meal).toUpperCase());
-        items.forEach(function (item) {
-            lines.push('  • ' + (item.name || '') + '  ' + (item.quantity || '') + ' ' + (item.unit || ''));
-        });
-        lines.push('');
+  /* ── Piano alimentare ── */
+  var pianoRows = '';
+  MEALS_ORDER.forEach(function(meal) {
+    var plan  = (mealPlan && mealPlan[meal]) ? mealPlan[meal] : {};
+    var allItems = [];
+    ['principale','contorno','frutta','extra'].forEach(function(cat){
+      if (Array.isArray(plan[cat])) plan[cat].forEach(function(i){ if(i&&i.name) allItems.push(i); });
     });
+    if (!allItems.length) return;
+    pianoRows +=
+      '<tr><td class="meal-label">'+MEAL_LABELS[meal]+'</td>' +
+      '<td>'+allItems.map(function(i){
+        return '<span class="ing-chip">'+i.name+(i.quantity?' <em>'+i.quantity+' '+(i.unit||'g')+'</em>':'')+'</span>';
+      }).join('')+'</td></tr>';
+  });
 
-    lines.push('═══════════════════════════════════');
-    lines.push('');
-
-    // Dispensa
-    var pantryKeys = Object.keys(pantryItems).filter(function (k) {
-        return (pantryItems[k].quantity || 0) > 0;
+  /* ── Dispensa ── */
+  var dispensaRows = '';
+  if (typeof pantryItems !== 'undefined' && pantryItems) {
+    Object.keys(pantryItems).sort().forEach(function(k){
+      var d = pantryItems[k];
+      if (!d || (d.quantity||0) <= 0) return;
+      dispensaRows += '<tr><td>'+k+'</td><td style="text-align:right;font-weight:600;">'+d.quantity+' '+(d.unit||'g')+'</td></tr>';
     });
-    if (pantryKeys.length) {
-        lines.push('DISPENSA ATTUALE');
-        lines.push('');
-        pantryKeys.forEach(function (name) {
-            var d = pantryItems[name];
-            lines.push('  • ' + name + ': ' + d.quantity + ' ' + d.unit);
-        });
-        lines.push('');
-        lines.push('═══════════════════════════════════');
-        lines.push('');
-    }
+  }
 
-    // Storico (ultimi 7 giorni)
-    var storicoKeys = Object.keys(appHistory).sort(function (a, b) {
-        return b.localeCompare(a);
-    }).slice(0, 7);
-    if (storicoKeys.length) {
-        lines.push('STORICO (ultimi 7 giorni)');
-        lines.push('');
-        var DAYS_IT   = ['Dom', 'Lun', 'Mar', 'Mer', 'Gio', 'Ven', 'Sab'];
-        var MONTHS_IT = ['Gen', 'Feb', 'Mar', 'Apr', 'Mag', 'Giu',
-                         'Lug', 'Ago', 'Set', 'Ott', 'Nov', 'Dic'];
-        storicoKeys.forEach(function (dk) {
-            var d = new Date(dk + 'T00:00:00');
-            var dayLabel = DAYS_IT[d.getDay()] + ' ' + d.getDate() + ' ' + MONTHS_IT[d.getMonth()];
-            var dayData  = appHistory[dk];
-            var usedItems = dayData.usedItems || {};
-            var totalUsed = 0;
-            Object.keys(usedItems).forEach(function (mk) {
-                totalUsed += Object.keys(usedItems[mk] || {}).length;
-            });
-            if (!totalUsed) return;
-            lines.push('▸ ' + dayLabel + ' (' + totalUsed + ' alimenti)');
-            MEALS_ORDER.forEach(function (meal) {
-                var mealUsed = usedItems[meal] || {};
-                var mealSubs = (dayData.substitutions || {})[meal] || {};
-                var planItems = (mealPlan[meal] && mealPlan[meal].principale) || [];
-                Object.keys(mealUsed).forEach(function (name) {
-                    var sub = mealSubs[name];
-                    var displayName = sub || name;
-                    lines.push('  [' + (MEAL_LABELS[meal] || meal) + '] ' + displayName);
-                });
-            });
-            lines.push('');
+  /* ── Storico (ultimi 7 giorni) ── */
+  var storicoHtml = '';
+  if (typeof appHistory !== 'undefined') {
+    var skeys = Object.keys(appHistory).sort(function(a,b){ return b.localeCompare(a); }).slice(0,7);
+    skeys.forEach(function(dk){
+      var d     = new Date(dk+'T00:00:00');
+      var label = DAYS_IT[d.getDay()]+' '+d.getDate()+' '+MONTHS_IT[d.getMonth()];
+      var hd    = appHistory[dk] || {};
+      var used  = hd.usedItems || {};
+      var subs  = hd.substitutions || {};
+      var ricette = hd.ricette || {};
+      var rows  = '';
+      MEALS_ORDER.forEach(function(mk){
+        var mUsed = used[mk] || {};
+        var mSubs = subs[mk] || {};
+        var mRic  = ricette[mk] || {};
+        var names = Object.keys(mUsed);
+        var ricNames = Object.keys(mRic);
+        if (!names.length && !ricNames.length) return;
+        rows += '<tr><td class="meal-label">'+MEAL_LABELS[mk]+'</td><td>';
+        names.forEach(function(n){
+          var s = mSubs[n];
+          rows += s ? '<span class="ing-chip sub">'+n+' → '+s+'</span>' : '<span class="ing-chip">'+n+'</span>';
         });
-    }
+        ricNames.forEach(function(n){ rows += '<span class="ing-chip ric">🍽 '+n+'</span>'; });
+        rows += '</td></tr>';
+      });
+      if (rows) storicoHtml += '<h3 class="day-label">'+label+'</h3><table class="data-table">'+rows+'</table>';
+    });
+  }
 
-    var content = lines.join('\n');
-    var blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
-    var url  = URL.createObjectURL(blob);
-    var a    = document.createElement('a');
-    a.href   = url;
-    a.download = 'nutriplan_' + new Date().toISOString().slice(0, 10) + '.txt';
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    URL.revokeObjectURL(url);
+  /* ── Spesa ── */
+  var spesaRows = '';
+  if (typeof spesaItems !== 'undefined' && Array.isArray(spesaItems)) {
+    spesaItems.forEach(function(i){
+      if (!i || !i.name) return;
+      var qty = i.quantity ? i.quantity+' '+(i.unit||'g') : '—';
+      spesaRows += '<tr'+(i.bought?' class="bought"':'')+'><td>'+(i.bought?'✅ ':'')+i.name+'</td><td style="text-align:right;">'+qty+'</td></tr>';
+    });
+  }
+
+  var html =
+    '<!DOCTYPE html><html lang="it"><head><meta charset="UTF-8">'+
+    '<title>NutriPlan — Export '+todayLabel+'</title>'+
+    '<style>'+
+      '*{box-sizing:border-box;margin:0;padding:0;}'+
+      'body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-size:13px;color:#1a2e22;padding:24px 32px;max-width:900px;margin:0 auto;}'+
+      'h1{font-size:1.5rem;color:#2d6e55;margin-bottom:4px;}'+
+      '.subtitle{font-size:.85rem;color:#6b7280;margin-bottom:24px;}'+
+      'h2{font-size:1.05rem;font-weight:700;color:#2d6e55;border-bottom:2px solid #4a9b7f;padding-bottom:4px;margin:28px 0 12px;}'+
+      'h3.day-label{font-size:.9rem;font-weight:700;color:#374151;margin:16px 0 6px;padding-left:4px;border-left:3px solid #4a9b7f;}'+
+      'table.data-table{width:100%;border-collapse:collapse;margin-bottom:10px;}'+
+      'table.data-table td{padding:6px 10px;border-bottom:1px solid #e5e7eb;vertical-align:top;}'+
+      'table.data-table tr:last-child td{border-bottom:none;}'+
+      '.meal-label{font-weight:700;white-space:nowrap;width:100px;color:#4a9b7f;}'+
+      '.ing-chip{display:inline-block;background:#f0faf5;border:1px solid #bbf0d9;border-radius:4px;padding:2px 7px;margin:2px 3px 2px 0;font-size:.8rem;}'+
+      '.ing-chip.sub{background:#fff3cd;border-color:#ffd166;}'+
+      '.ing-chip.ric{background:#ede9fe;border-color:#c4b5fd;}'+
+      '.ing-chip em{color:#6b7280;font-style:normal;}'+
+      'tr.bought td{color:#9ca3af;text-decoration:line-through;}'+
+      '@media print{body{padding:12px 16px;}h2{page-break-before:auto;}}'+
+    '</style></head><body>'+
+    '<h1>🌿 NutriPlan</h1>'+
+    '<div class="subtitle">Esportato il '+todayLabel+'</div>'+
+
+    '<h2>📋 Piano alimentare</h2>'+
+    (pianoRows
+      ? '<table class="data-table">'+pianoRows+'</table>'
+      : '<p style="color:#9ca3af;">Nessun piano configurato.</p>')+
+
+    (dispensaRows
+      ? '<h2>🗄️ Dispensa</h2><table class="data-table">'+dispensaRows+'</table>'
+      : '')+
+
+    (storicoHtml
+      ? '<h2>📅 Storico pasti (ultimi 7 giorni)</h2>'+storicoHtml
+      : '')+
+
+    (spesaRows
+      ? '<h2>🛒 Lista spesa</h2><table class="data-table">'+spesaRows+'</table>'
+      : '')+
+
+    '<script>window.onload=function(){window.print();}<\/script>'+
+    '</body></html>';
+
+  var win = window.open('', '_blank');
+  if (!win) {
+    if (typeof showToast === 'function') showToast('⚠️ Abilita i popup per esportare in PDF','warning');
+    return;
+  }
+  win.document.open();
+  win.document.write(html);
+  win.document.close();
 }

--- a/profilo.js
+++ b/profilo.js
@@ -11,8 +11,11 @@ function renderProfilo() {
   if (!el) return;
   el.innerHTML =
     buildProfiloUserSection() +
+    buildProfiloPianoSection() +
     buildProfiloLimitiSection() +
-    buildProfiloPianoSection();
+    buildProfiloStoricoSection();
+  /* Render storico nell'apposito contenitore */
+  if (typeof renderStorico === 'function') renderStorico('profiloStoricoContent');
 }
 
 /* ══════════════════════════════════════════════
@@ -289,6 +292,23 @@ function saveEditPiano() {
   saveData();
   renderProfilo();
   if (typeof renderMealPlan === 'function') renderMealPlan();
+}
+
+/* ══════════════════════════════════════════════
+   SEZIONE STORICO (incorporata nel profilo)
+══════════════════════════════════════════════ */
+function buildProfiloStoricoSection() {
+  return (
+    '<div class="rc-card" style="margin-bottom:16px;">' +
+      '<div style="padding:16px 20px 12px;display:flex;align-items:center;gap:10px;border-bottom:1px solid var(--border);">' +
+        '<span style="font-size:1.3em;">📅</span>' +
+        '<span style="font-weight:700;font-size:1.05em;">Storico pasti</span>' +
+      '</div>' +
+      '<div style="padding:16px 20px;">' +
+        '<div id="profiloStoricoContent"></div>' +
+      '</div>' +
+    '</div>'
+  );
 }
 
 /* ── UTILITY ── */

--- a/spesa.js
+++ b/spesa.js
@@ -1,6 +1,121 @@
 /*
-   SPESA.JS — v4  stile rc-card unificato
+   SPESA.JS — v5  stile rc-card unificato
 */
+
+/* ── Stato selezione ricette ── */
+var selectedSpesaRecipes    = {};
+var spesaGenerateDays       = 1;
+var spesaRecipeSelectorOpen = false;
+
+/* ══════════════════════════════════════════════
+   PANNELLO GENERA
+══════════════════════════════════════════════ */
+function buildSpesaGeneratePanel() {
+  var allRicette = (typeof getAllRicette === 'function') ? getAllRicette() : [];
+  var selCount   = Object.keys(selectedSpesaRecipes).filter(function(k){ return selectedSpesaRecipes[k]; }).length;
+
+  var recipeRows = allRicette.map(function(r){
+    var name    = r.name || r.nome || '';
+    var icon    = r.icon || r.icona || '🍽';
+    var checked = selectedSpesaRecipes[name] ? true : false;
+    return '<label style="display:flex;align-items:center;gap:10px;padding:8px 12px;border-radius:var(--r-sm);cursor:pointer;background:'+(checked?'var(--primary-xl)':'var(--bg-subtle)')+';border:1.5px solid '+(checked?'var(--primary-mid)':'transparent')+';">' +
+      '<input type="checkbox" '+(checked?'checked':'')+' onchange="toggleSpesaRecipe(\''+_escSpesa(name)+'\')" style="width:16px;height:16px;accent-color:var(--primary);">' +
+      '<span style="font-size:1.1em;">'+icon+'</span>' +
+      '<span style="flex:1;font-size:.88em;font-weight:500;">'+name+'</span>' +
+      '<span style="font-size:.75em;color:var(--text-light);">'+(r.pasto||'')+'</span>' +
+    '</label>';
+  }).join('');
+
+  var selectorHtml = spesaRecipeSelectorOpen
+    ? '<div style="background:var(--bg-card);border:1.5px solid var(--border);border-radius:var(--r-md);padding:12px;margin-bottom:10px;">' +
+        '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;">' +
+          '<span style="font-weight:700;font-size:.9em;">Seleziona ricette</span>' +
+          '<button class="rc-btn-icon" onclick="spesaRecipeSelectorOpen=false;renderSpesa()">✕</button>' +
+        '</div>' +
+        '<div style="max-height:220px;overflow-y:auto;display:flex;flex-direction:column;gap:4px;">' +
+          (recipeRows || '<p style="color:var(--text-3);font-size:.85em;">Nessuna ricetta disponibile.</p>') +
+        '</div>' +
+        '<div style="display:flex;align-items:center;gap:8px;margin-top:10px;flex-wrap:wrap;">' +
+          '<button class="rc-btn rc-btn-primary rc-btn-sm" onclick="generateFromSelectedRecipes()" '+(selCount?'':'disabled style="opacity:.5;"')+'>'+
+            '📋 Genera da ricette selezionate ('+selCount+')'+
+          '</button>' +
+          '<button class="rc-btn rc-btn-outline rc-btn-sm" onclick="toggleAllSpesaRecipes()">'+
+            (selCount===allRicette.length ? '☐ Deseleziona tutte' : '☑ Seleziona tutte') +
+          '</button>' +
+        '</div>' +
+      '</div>'
+    : '';
+
+  return (
+    '<div style="background:var(--bg-subtle);border:1.5px solid var(--border);border-radius:var(--r-md);padding:12px;margin-bottom:16px;">' +
+      '<div style="font-weight:700;font-size:.85em;text-transform:uppercase;letter-spacing:.07em;color:var(--text-light);margin-bottom:10px;">⚡ Genera lista</div>' +
+
+      /* Genera da piano */
+      '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:8px;">' +
+        '<button class="rc-btn rc-btn-primary rc-btn-sm" onclick="generateShoppingList()">🗓 Da piano alimentare</button>' +
+        '<div style="display:flex;align-items:center;gap:6px;">' +
+          '<label style="font-size:.82em;color:var(--text-2);">×</label>' +
+          '<input type="number" min="1" max="14" value="'+spesaGenerateDays+'" ' +
+                 'onchange="spesaGenerateDays=Math.max(1,parseInt(this.value)||1);this.value=spesaGenerateDays" ' +
+                 'style="width:52px;padding:4px 6px;border:1.5px solid var(--border);border-radius:var(--r-sm);background:var(--bg-card);color:var(--text-1);font-size:.88em;text-align:center;">' +
+          '<label style="font-size:.82em;color:var(--text-2);">giorni</label>' +
+        '</div>' +
+      '</div>' +
+
+      /* Genera da ricette */
+      '<button class="rc-btn rc-btn-outline rc-btn-sm" onclick="spesaRecipeSelectorOpen=!spesaRecipeSelectorOpen;renderSpesa()">'+
+        '🍽 Da ricette selezionate'+(selCount?' ('+selCount+')':'')+' ▾' +
+      '</button>' +
+      selectorHtml +
+    '</div>'
+  );
+}
+
+function _escSpesa(str) {
+  return String(str).replace(/\\/g,'\\\\').replace(/'/g,"\\'").replace(/"/g,'&quot;');
+}
+
+function toggleSpesaRecipe(name) {
+  selectedSpesaRecipes[name] = !selectedSpesaRecipes[name];
+  renderSpesa();
+}
+
+function toggleAllSpesaRecipes() {
+  var all = (typeof getAllRicette === 'function') ? getAllRicette() : [];
+  var selCount = Object.keys(selectedSpesaRecipes).filter(function(k){ return selectedSpesaRecipes[k]; }).length;
+  selectedSpesaRecipes = {};
+  if (selCount < all.length) {
+    all.forEach(function(r){ selectedSpesaRecipes[r.name||r.nome||''] = true; });
+  }
+  renderSpesa();
+}
+
+function generateFromSelectedRecipes() {
+  var selected = Object.keys(selectedSpesaRecipes).filter(function(k){ return selectedSpesaRecipes[k]; });
+  if (!selected.length) { if (typeof showToast==='function') showToast('⚠️ Seleziona almeno una ricetta','warning'); return; }
+  var needed = {};
+  selected.forEach(function(name){
+    var r = (typeof findRicetta === 'function') ? findRicetta(name) : null;
+    if (!r) return;
+    var ings = Array.isArray(r.ingredienti) ? r.ingredienti : [];
+    ings.forEach(function(ing){
+      var iname = (ing.name||ing.nome||'').trim();
+      if (!iname) return;
+      var qty   = parseFloat(ing.quantity) || 0;
+      var unit  = ing.unit || 'g';
+      if (!needed[iname]) needed[iname] = { name:iname, quantity:0, unit:unit, manual:false, bought:false };
+      needed[iname].quantity += qty;
+    });
+  });
+  var manual = (typeof spesaItems !== 'undefined' ? spesaItems : []).filter(function(i){ return i.manual; });
+  spesaItems = manual.concat(Object.values(needed).map(function(i){
+    return Object.assign({}, i, { quantity: i.quantity > 0 ? i.quantity : null });
+  }));
+  saveData();
+  spesaRecipeSelectorOpen = false;
+  renderSpesa();
+  if (typeof showToast==='function') showToast('✅ Lista generata da '+selected.length+' ricett'+(selected.length===1?'a':'e'),'success');
+}
 
 /* ══════════════════════════════════════════════
    RENDER PRINCIPALE
@@ -15,11 +130,11 @@ function renderSpesa() {
 
   /* ── toolbar ── */
   var toolbar =
-    '<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:16px;">' +
-      '<button class="rc-btn rc-btn-primary" onclick="generateShoppingList()">⚡ Genera</button>' +
+    '<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px;">' +
       '<button class="rc-btn rc-btn-outline" onclick="openSpesaItemModal()">＋ Aggiungi</button>' +
-      '<button class="rc-btn rc-btn-outline" onclick="clearBoughtItems()">🗑️ Rimuovi acquistati</button>' +
-    '</div>';
+      '<button class="rc-btn rc-btn-outline" onclick="clearBoughtItems()">🗑️ Acquistati</button>' +
+    '</div>' +
+    buildSpesaGeneratePanel();
 
   if (!items.length) {
     el.innerHTML =
@@ -112,8 +227,9 @@ function clearBoughtItems() {
   renderSpesa();
 }
 
-/* ── GENERA DA PIANO ── */
+/* ── GENERA DA PIANO (× giorni) ── */
 function generateShoppingList() {
+  var days   = typeof spesaGenerateDays !== 'undefined' ? (parseInt(spesaGenerateDays)||1) : 1;
   var needed = {};
   ['colazione','spuntino','pranzo','merenda','cena'].forEach(function(mk){
     var plan = (mealPlan && mealPlan[mk]) ? mealPlan[mk] : {};
@@ -121,11 +237,14 @@ function generateShoppingList() {
       if (!Array.isArray(plan[cat])) return;
       plan[cat].forEach(function(item){
         if (!item || !item.name) return;
-        var name = item.name.trim();
-        var inFridge = typeof pantryItems !== 'undefined' && pantryItems &&
+        var name    = item.name.trim();
+        var inPantry = typeof pantryItems !== 'undefined' && pantryItems &&
                        pantryItems[name] && (pantryItems[name].quantity||0) > 0;
-        if (!inFridge) {
-          if (!needed[name]) needed[name] = { name:name, quantity:item.quantity||null, unit:item.unit||'g', manual:false, bought:false };
+        if (!inPantry) {
+          var baseQty = parseFloat(item.quantity) || 0;
+          var totalQty = baseQty * days;
+          if (!needed[name]) needed[name] = { name:name, quantity:totalQty||null, unit:item.unit||'g', manual:false, bought:false };
+          else if (totalQty > 0) needed[name].quantity = (needed[name].quantity||0) + totalQty;
         }
       });
     });
@@ -136,6 +255,7 @@ function generateShoppingList() {
   spesaItems = manual.concat(Object.values(needed));
   saveData();
   renderSpesa();
+  if (typeof showToast==='function') showToast('✅ Lista generata per '+days+' giorn'+(days===1?'o':'i'),'success');
 }
 
 /* ── MODAL AGGIUNGI MANUALE ── */

--- a/storico.js
+++ b/storico.js
@@ -4,8 +4,8 @@
 
 var storicoOpenDays = {};
 
-function renderStorico() {
-  var el = document.getElementById('storicoContent');
+function renderStorico(targetId) {
+  var el = document.getElementById(targetId || 'storicoContent');
   if (!el) return;
 
   var keys = Object.keys(appHistory).sort(function(a,b){ return b.localeCompare(a); });
@@ -135,6 +135,7 @@ function deleteStoricoDay(dk) {
   delete appHistory[dk];
   saveData();
   renderStorico();
+  renderStorico('profiloStoricoContent');
 }
 
 /* ── FORMATTA DATA ── */


### PR DESCRIPTION
…xport, spesa multi-select

- Rename Frigo→Dispensa everywhere (nav, modals, toasts, page IDs)
- Remove Storico from main nav; embed as section in Profilo
- Piano: sort recipes by ingredient availability, disable "Scegli" when ingredients missing
- Piano: record chosen recipes in storico (appHistory.ricette)
- Piano: category-compatible substitutions (same macro group only)
- Piano: "in dispensa" badge text
- app.js: add addFromSpesa() for automatic pantry update from shopping list
- app.js: goToPage renders dict updated (frigo→dispensa, storico removed)
- spesa.js: recipe multi-select panel with generate-from-recipes and generate-from-plan×days
- profilo.js: Piano section before Limiti; storico sub-section added
- pdf.js: rewrite to print-ready HTML (opens new tab + window.print())
- components.css: add .rm-* classes for recipe modal aesthetics

https://claude.ai/code/session_01M1GVquV1FmGgSmbYTyoAwW