### PR TITLE
Fix multiple UI bugs and add Piano Alimentare improvements

### DIFF
--- a/app.js
+++ b/app.js
@@ -86,12 +86,14 @@ function initDarkMode() {
 function applyDarkMode(isDark, save) {
   if (save === undefined) save = true;
   document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light');
-  /* Aggiorna icona bottone tema — supporta sia id darkToggle che btn-icon-only nel header */
-  var btn = document.getElementById('darkToggle');
-  if (btn) btn.textContent = isDark ? '☀️' : '🌙';
-  /* Aggiorna tutti i bottoni tema nell'header (classe btn-icon-only con 🌙/☀️) */
+  /* Aggiorna tutti i bottoni tema — supporta id darkToggle, themeToggle e data-theme-toggle */
+  var icon = isDark ? '☀️' : '🌙';
+  ['darkToggle', 'themeToggle'].forEach(function(id) {
+    var b = document.getElementById(id);
+    if (b) b.textContent = icon;
+  });
   document.querySelectorAll('[data-theme-toggle]').forEach(function(b) {
-    b.textContent = isDark ? '☀️' : '🌙';
+    b.textContent = icon;
   });
   var meta = document.getElementById('metaThemeColor');
   if (meta) meta.content = isDark ? '#152318' : '#4a9b7f';
@@ -866,7 +868,7 @@ function enterApp() {
 
   buildCalendarBar();
   updateDateLabel();
-  goToPage('piano');
+  goToPage('piano-alimentare');
 
   /* Prima mostra onboarding (piano alimentare), poi tutorial */
   if (typeof checkOnboarding === 'function') {

--- a/components.css
+++ b/components.css
@@ -1803,31 +1803,37 @@
   margin-top: 20px;
 }
 .pa-limiti-header {
-  display: flex; align-items: center; gap: 10px;
-  padding: 14px 18px; border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  padding: 12px 16px; border-bottom: 1px solid var(--border);
   background: color-mix(in srgb, var(--primary) 5%, var(--bg-card));
 }
-.pa-limiti-icon  { font-size: 1.3rem; }
-.pa-limiti-title { font-size: .88rem; font-weight: 800; }
+.pa-limiti-icon  { font-size: 1.2rem; flex-shrink: 0; }
+.pa-limiti-title { font-size: .88rem; font-weight: 800; flex: 1; min-width: 0; }
+.pa-limiti-sub   { font-size: .72rem; color: var(--text-light); flex-shrink: 0; }
 .pa-limiti-body  { padding: 8px 0; }
 
 .pa-limit-row {
-  display: flex; align-items: center; gap: 12px;
-  padding: 10px 18px;
+  display: flex; align-items: center; gap: 8px;
+  padding: 9px 14px;
   border-bottom: 1px solid var(--border);
+  min-width: 0;
 }
 .pa-limit-row:last-child { border-bottom: none; }
 
-.pa-limit-icon  { font-size: 1.2rem; flex-shrink: 0; width: 26px; text-align: center; }
-.pa-limit-label { flex: 1; font-size: .88rem; font-weight: 600; }
-.pa-limit-unit  { font-size: .72rem; color: var(--text-light); font-weight: 600; flex-shrink: 0; }
+.pa-limit-icon  { font-size: 1.1rem; flex-shrink: 0; width: 24px; text-align: center; }
+.pa-limit-info  { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.pa-limit-label { font-size: .84rem; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pa-limit-unit  { font-size: .68rem; color: var(--text-light); }
+.pa-limit-right { display: flex; align-items: center; gap: 5px; flex-shrink: 0; }
+.pa-limit-cur   { font-size: .68rem; color: var(--text-light); white-space: nowrap; }
+.pa-limit-max-label { font-size: .7rem; font-weight: 700; color: var(--text-light); }
 .pa-limit-input {
-  width: 72px; text-align: center;
-  padding: 6px 8px;
+  width: 58px; text-align: center;
+  padding: 5px 6px;
   border: 1.5px solid var(--border);
   border-radius: var(--r-md);
   background: var(--bg); color: var(--text);
-  font-size: .9rem; font-weight: 700;
+  font-size: .88rem; font-weight: 700;
   flex-shrink: 0;
 }
 .pa-limit-input:focus {

--- a/index.html
+++ b/index.html
@@ -770,6 +770,44 @@
   </div>
 </div>
 
+<!-- Modale: quantità ingrediente (Piano Alimentare) -->
+<div class="modal" id="paQtyModal">
+  <div class="modal-box" style="max-width:360px;">
+    <div class="modal-handle"></div>
+    <div class="modal-header">
+      <h2 class="modal-title" id="paQtyTitle">＋ Aggiungi ingrediente</h2>
+      <button class="modal-close" onclick="closePAQtyModal()">✕</button>
+    </div>
+    <div class="modal-body">
+      <p style="font-size:.88rem;font-weight:700;margin-bottom:14px;" id="paQtyIngName"></p>
+      <div class="row gap-8">
+        <div class="form-group flex1">
+          <label>Quantità (opzionale)</label>
+          <input type="number" id="paQtyInput" min="0" step="any" placeholder="—">
+        </div>
+        <div class="form-group" style="width:110px">
+          <label>Unità</label>
+          <select id="paQtyUnit">
+            <option value="g">g</option>
+            <option value="ml">ml</option>
+            <option value="pz">pz</option>
+            <option value="fette">fette</option>
+            <option value="cucchiai">cucchiai</option>
+            <option value="cucchiaini">cucchiaini</option>
+            <option value="porzione">porzione</option>
+            <option value="kg">kg</option>
+            <option value="l">l</option>
+          </select>
+        </div>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="btn btn-secondary" onclick="closePAQtyModal()">Annulla</button>
+      <button class="btn btn-primary" onclick="confirmPAQty()">Aggiungi ✓</button>
+    </div>
+  </div>
+</div>
+
 <!-- Modale: selezione ingrediente per Piano Alimentare -->
 <div class="modal" id="paIngModal">
   <div class="modal-box">

--- a/profilo.js
+++ b/profilo.js
@@ -376,13 +376,40 @@ function buildProfiloSettingsSection() {
 
 function confirmClearAllData() {
   if (!confirm('Cancellare TUTTI i dati di NutriPlan?\nQuesta operazione è irreversibile.')) return;
-  if (!confirm('Sei sicuro? Dispensa, piano, storico e spesa verranno eliminati.')) return;
-  if (typeof pantryItems  !== 'undefined') pantryItems  = {};
-  if (typeof mealPlan     !== 'undefined') mealPlan     = {};
-  if (typeof appHistory   !== 'undefined') appHistory   = {};
-  if (typeof spesaItems   !== 'undefined') spesaItems   = [];
-  if (typeof weeklyLimits !== 'undefined') weeklyLimits = {};
+  if (!confirm('Sei sicuro? Dispensa, piano alimentare, storico e spesa verranno eliminati.')) return;
+
+  /* Azzeramento locale */
+  if (typeof pantryItems          !== 'undefined') pantryItems          = {};
+  if (typeof mealPlan             !== 'undefined') mealPlan             = {};
+  if (typeof appHistory           !== 'undefined') appHistory           = {};
+  if (typeof spesaItems           !== 'undefined') spesaItems           = [];
+  if (typeof pianoAlimentare      !== 'undefined') pianoAlimentare      = {};
+  if (typeof weeklyLimitsCustom   !== 'undefined') weeklyLimitsCustom   = {};
+  if (typeof customRecipes        !== 'undefined') customRecipes        = [];
+  if (typeof customIngredients    !== 'undefined') customIngredients    = [];
+  if (typeof savedFridges         !== 'undefined') savedFridges         = {};
+  if (typeof weeklyLimits         !== 'undefined') {
+    /* Resetta solo i current, mantieni la struttura */
+    Object.keys(weeklyLimits).forEach(function(k) {
+      if (weeklyLimits[k]) weeklyLimits[k].current = 0;
+    });
+  }
+
+  /* Elimina localStorage completamente e ri-salva vuoto */
+  try { localStorage.removeItem('nutriplan_v2'); } catch(e) {}
   if (typeof saveData === 'function') saveData();
+
+  /* Elimina anche da Firebase se l'utente è loggato */
+  var user = (typeof currentUser !== 'undefined') ? currentUser : null;
+  if (user && typeof firebase !== 'undefined' && firebase.database) {
+    try {
+      firebase.database()
+        .ref('users/' + user.uid + '/nutriplan')
+        .remove()
+        .catch(function(e) { console.warn('Firebase remove error:', e); });
+    } catch(e) {}
+  }
+
   renderProfilo();
   if (typeof showToast === 'function') showToast('🗑️ Tutti i dati eliminati', 'info');
 }

--- a/tutorial.js
+++ b/tutorial.js
@@ -22,12 +22,21 @@ var TUTORIAL_STEPS = [
     hint:   ''
   },
   {
+    icon:   '🌿',
+    title:  'Piano Alimentare',
+    text:   'Qui imposti il tuo piano: per ogni pasto scegli le categorie di ingredienti e le alternative. In fondo puoi impostare i limiti settimanali.',
+    page:   'piano-alimentare',
+    target: '#bn-piano-alimentare,#st-piano-alimentare',
+    hint:   'Tocca "Piano" per aprire la sezione',
+    autoAdvance: true
+  },
+  {
     icon:   '🍽',
     title:  'Cosa mangio oggi',
     text:   'Qui vedi il tuo piano giornaliero. Tocca un pasto e spunta ✅ gli ingredienti man mano che li consumi.',
     page:   'piano',
-    target: '#mealSelector',
-    hint:   'Tocca un pasto per selezionarlo',
+    target: '#bn-piano,#st-piano',
+    hint:   'Tocca "Oggi" per aprire la sezione',
     autoAdvance: true
   },
   {
@@ -55,15 +64,6 @@ var TUTORIAL_STEPS = [
     page:   'spesa',
     target: '#bn-spesa,#st-spesa',
     hint:   'Tocca "Spesa" per aprire la sezione',
-    autoAdvance: true
-  },
-  {
-    icon:   '📊',
-    title:  'Statistiche & Storico',
-    text:   'Grafici del tuo percorso alimentare e calendario per navigare tra i giorni passati e futuri.',
-    page:   'statistiche',
-    target: '#bn-stats,#st-stats',
-    hint:   'Tocca "Stats" per aprire la sezione',
     autoAdvance: true
   },
   {
@@ -217,12 +217,22 @@ function _clearAutoAdvance() {
 }
 
 function _setupAutoAdvance(targetSelector) {
-  /* Trova il primo elemento target disponibile */
+  /* Trova il primo elemento target VISIBILE disponibile */
   var el   = null;
   var sels = targetSelector.split(',');
   for (var i = 0; i < sels.length; i++) {
     var found = document.querySelector(sels[i].trim());
-    if (found) { el = found; break; }
+    if (found) {
+      var r = found.getBoundingClientRect();
+      if (r.width > 0 || r.height > 0) { el = found; break; }
+    }
+  }
+  /* Fallback: qualsiasi elemento presente */
+  if (!el) {
+    for (var j = 0; j < sels.length; j++) {
+      var fb = document.querySelector(sels[j].trim());
+      if (fb) { el = fb; break; }
+    }
   }
   if (!el) return;
 
@@ -262,12 +272,23 @@ function _positionStep(step) {
     return;
   }
 
-  /* Find target element (try comma-separated selectors) */
+  /* Find first VISIBLE target element (try comma-separated selectors one by one) */
   var el   = null;
   var sels = step.target.split(',');
+  /* Pass 1: cerca il primo con dimensioni reali (visibile) */
   for (var i = 0; i < sels.length; i++) {
     var found = document.querySelector(sels[i].trim());
-    if (found) { el = found; break; }
+    if (found) {
+      var r = found.getBoundingClientRect();
+      if (r.width > 0 || r.height > 0) { el = found; break; }
+    }
+  }
+  /* Pass 2: fallback — qualsiasi elemento che esiste nel DOM */
+  if (!el) {
+    for (var j = 0; j < sels.length; j++) {
+      var fb = document.querySelector(sels[j].trim());
+      if (fb) { el = fb; break; }
+    }
   }
 
   if (!el) {


### PR DESCRIPTION
- Fix selectPAIng bug: save modal state vars before closePAIngModal resets them
- Add quantity step modal (paQtyModal) for ingredient quantity input
- Fix dark mode toggle: update both #darkToggle and #themeToggle icons
- Set Piano Alimentare as default page on app start
- Fix confirmClearAllData: clear pianoAlimentare, customIngredients, Firebase data
- Fix tutorial spotlight: two-pass visible element finder (skip display:none elements)
- Fix limits section CSS overflow: add pa-limit-info/right/cur/max-label rules
- Remove 'Altro' from predefined PA_CATEGORIES (dynamic only)
- Add piano-alimentare step to tutorial, remove statistiche step

https://claude.ai/code/session_01UbdJ9bh3WzYsXb8nst9wHk