### PR TITLE
Fix duplicate Firebase auth listeners causing verification loop

### DIFF
--- a/app.js
+++ b/app.js
@@ -784,13 +784,8 @@ document.addEventListener('DOMContentLoaded', function() {
     startApp();
   }
 
-  /* Firebase auth listener */
-  if (typeof firebase !== 'undefined' && firebase.auth) {
-    firebase.auth().onAuthStateChanged(function(user) {
-      window.currentUser = user || null;
-      updateAuthUI(user);
-    });
-  }
+  /* FIX: listener rimosso — gestito esclusivamente in firebase-config.js
+     per evitare registrazioni duplicate che causavano il loop "Verifica accesso" */
 });
 /* ============================================================
    BRIDGE SHIM — collega index.html v2 con app.js esistente
@@ -827,10 +822,9 @@ function _hideCookieBanner() {
    LANDING — login gate helpers
 ══════════════════════════════════════════════════ */
 function landingSignIn() {
-  if (typeof initFirebase === 'function') initFirebase();
-  setTimeout(function() {
-    if (typeof signInWithGoogle === 'function') signInWithGoogle();
-  }, 100);
+  /* FIX: initFirebase() rimossa — già inizializzato in DOMContentLoaded;
+     ri-chiamarla registrava listener duplicati */
+  if (typeof signInWithGoogle === 'function') signInWithGoogle();
 }
 
 function landingOffline() {
@@ -856,8 +850,10 @@ function enterApp() {
   initIcons();
   initIosBanner();
 
-  if (typeof initFirebase === 'function') initFirebase();
-  if (typeof loadData === 'function')     loadData();
+  /* FIX: initFirebase() rimossa da qui — era già chiamata in DOMContentLoaded e
+     registrava un nuovo onAuthStateChanged ad ogni enterApp(), creando listener
+     duplicati e il loop "Verifica accesso" */
+  if (typeof loadData === 'function') loadData();
 
   if (!window.selectedDateKey && typeof getCurrentDateKey === 'function') {
     window.selectedDateKey = getCurrentDateKey();


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where Firebase's `onAuthStateChanged` listener was being registered multiple times, causing an infinite "Verifica accesso" (Verify access) loop that prevented users from accessing the app.

## Key Changes

- **Consolidated Firebase initialization**: Moved `initFirebase()` call to run only once during `DOMContentLoaded`, removing duplicate calls from `landingSignIn()` and `enterApp()`
- **Added auth listener guard**: Introduced `_authListenerRegistered` flag to ensure `onAuthStateChanged` is registered exactly once, preventing duplicate listener callbacks
- **Implemented fallback timeout**: Added 8-second timeout that unlocks landing page buttons if Firebase doesn't respond, preventing indefinite spinner states
- **Removed duplicate listener in app.js**: Deleted the redundant `onAuthStateChanged` registration from the `DOMContentLoaded` event handler that was conflicting with the one in `firebase-config.js`
- **Improved error handling**: Added `updateAuthUI(null)` calls in error paths to unlock UI when Firebase initialization fails

## Implementation Details

- The guard flag `_authListenerRegistered` prevents re-registration even if `initFirebase()` is accidentally called multiple times
- The fallback timer (`_landingFallbackTimer`) is cleared as soon as the auth state listener responds, ensuring it only triggers if Firebase is unresponsive
- All changes maintain backward compatibility while fixing the root cause of the verification loop

https://claude.ai/code/session_01Cvgdki5i3cpx3HjRXwPPDx