### PR TITLE
Configure Firebase for hosting with automatic init.js injection

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -9,8 +9,12 @@
              signInWithGoogle, signOut, showCloudStatus
 ============================================================ */
 
-/* ── CONFIGURAZIONE — caricata da config.js (gitignored) ── */
-var firebaseConfig = (window.APP_CONFIG && window.APP_CONFIG.firebase) || {};
+/* ── CONFIGURAZIONE ────────────────────────────────────────
+   In produzione (Firebase Hosting) la config viene iniettata
+   automaticamente da /__/firebase/init.js — non serve config.js.
+   In sviluppo locale, config.js può fornire un fallback.
+────────────────────────────────────────────────────────── */
+var firebaseConfig = (window.APP_CONFIG && window.APP_CONFIG.firebase) || null;
 
 /* ── VARIABILI GLOBALI (usate da storage.js e app.js) ───── */
 var firebaseReady = false;
@@ -40,8 +44,20 @@ function initFirebase() {
   }
 
   try {
-    /* Evita doppia inizializzazione */
+    /* Evita doppia inizializzazione.
+       /__/firebase/init.js (caricato in <head>) inizializza già l'app in produzione:
+       firebase.apps.length > 0 → saltiamo initializeApp.
+       In sviluppo locale con config.js presente, inizializziamo qui. */
     if (!firebase.apps || firebase.apps.length === 0) {
+      if (!firebaseConfig) {
+        /* Né /__/firebase/init.js né config.js hanno fornito la config */
+        console.warn('[NutriPlan] Nessuna configurazione Firebase trovata. ' +
+          'In produzione usa Firebase Hosting; in sviluppo crea config.js da config.example.js.');
+        firebaseReady = false;
+        showCloudStatus('local');
+        if (typeof updateAuthUI === 'function') updateAuthUI(null);
+        return;
+      }
       firebase.initializeApp(firebaseConfig);
     }
 

--- a/index.html
+++ b/index.html
@@ -25,10 +25,15 @@
   <link rel="stylesheet" href="components.css">
   <link rel="stylesheet" href="utils.css">
 
-  <!-- Firebase SDK — devono stare PRIMA di firebase-config.js -->
-  <script src="https://www.gstatic.com/firebasejs/10.14.1/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.14.1/firebase-auth-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.14.1/firebase-database-compat.js"></script>
+  <!-- Firebase SDK via URL riservate Firebase Hosting.
+       /__/firebase/init.js inietta automaticamente la config del progetto
+       ed esegue firebase.initializeApp() — nessun config.js necessario in produzione.
+       Fallback: se config.js esiste localmente (sviluppo), firebase-config.js usa
+       la guard firebase.apps.length===0 per non inizializzare due volte. -->
+  <script src="/__/firebase/10.14.1/firebase-app-compat.js"></script>
+  <script src="/__/firebase/10.14.1/firebase-auth-compat.js"></script>
+  <script src="/__/firebase/10.14.1/firebase-database-compat.js"></script>
+  <script src="/__/firebase/init.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
This PR updates the Firebase configuration to leverage Firebase Hosting's automatic initialization mechanism (`/__/firebase/init.js`) while maintaining backward compatibility with local development setups using `config.js`.

## Key Changes

- **firebase-config.js**
  - Changed default `firebaseConfig` from empty object `{}` to `null` to distinguish between "not provided" and "empty config"
  - Enhanced comments to explain production vs. development configuration flows
  - Added guard logic to detect when `/__/firebase/init.js` has already initialized Firebase in production
  - Added fallback error handling when no Firebase config is available from either source, with user-friendly warning message and graceful degradation to local-only mode

- **index.html**
  - Updated Firebase SDK script URLs from CDN (`https://www.gstatic.com/firebasejs/...`) to Firebase Hosting reserved URLs (`/__/firebase/...`)
  - Added `/__/firebase/init.js` script tag to enable automatic Firebase initialization in production
  - Updated comments to clarify the dual-mode behavior: automatic injection in production, optional `config.js` fallback in development

## Implementation Details

The changes implement a smart initialization strategy:
1. **Production (Firebase Hosting)**: `/__/firebase/init.js` automatically injects the project config and initializes Firebase before `firebase-config.js` runs
2. **Development (local)**: If `config.js` exists, `firebase-config.js` detects that Firebase isn't yet initialized and performs initialization
3. **Fallback**: If neither source provides config, the app gracefully switches to local-only mode with appropriate warnings

This eliminates the need for `config.js` in production while maintaining full local development support.

https://claude.ai/code/session_01NNE6MVziG9Jb89azUxzL1Y