### PR TITLE
Support GitHub Pages deployment with dynamic base path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Genera config.js dai GitHub Secrets
+        run: |
+          cat > config.js << 'ENDOFCONFIG'
+          window.APP_CONFIG = {
+            firebase: {
+              apiKey:            "${{ secrets.FIREBASE_API_KEY }}",
+              authDomain:        "${{ secrets.FIREBASE_AUTH_DOMAIN }}",
+              databaseURL:       "${{ secrets.FIREBASE_DATABASE_URL }}",
+              projectId:         "${{ secrets.FIREBASE_PROJECT_ID }}",
+              storageBucket:     "${{ secrets.FIREBASE_STORAGE_BUCKET }}",
+              messagingSenderId: "${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}",
+              appId:             "${{ secrets.FIREBASE_APP_ID }}"
+            },
+            gemini: {
+              apiKey: "${{ secrets.GEMINI_API_KEY }}"
+            }
+          };
+          ENDOFCONFIG
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '.'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/app.js
+++ b/app.js
@@ -4,9 +4,11 @@
 ============================================================ */
 
 /* ── Registra Service Worker (PWA) ── */
+/* Usa path relativo ('sw.js') invece di assoluto ('/sw.js')
+   così funziona sia in root che in sottocartella (es. GitHub Pages project page) */
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', function() {
-    navigator.serviceWorker.register('/sw.js').catch(function(e) {
+    navigator.serviceWorker.register('sw.js').catch(function(e) {
       console.warn('[NutriPlan] SW registration failed:', e);
     });
   });

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -10,11 +10,17 @@
 ============================================================ */
 
 /* ── CONFIGURAZIONE ────────────────────────────────────────
-   In produzione (Firebase Hosting) la config viene iniettata
-   automaticamente da /__/firebase/init.js — non serve config.js.
-   In sviluppo locale, config.js può fornire un fallback.
+   La config viene iniettata da config.js:
+   - In produzione (GitHub Pages): generato da GitHub Actions via Secrets.
+   - In sviluppo locale: copia config.example.js → config.js con le tue chiavi.
+   Il SDK Firebase è caricato dal CDN pubblico gstatic.com (index.html).
 ────────────────────────────────────────────────────────── */
-var firebaseConfig = (window.APP_CONFIG && window.APP_CONFIG.firebase) || null;
+var _rawCfg = (window.APP_CONFIG && window.APP_CONFIG.firebase) || null;
+/* Valida: scarta la config se apiKey è vuota o contiene placeholder */
+var firebaseConfig = (_rawCfg && _rawCfg.apiKey &&
+                      _rawCfg.apiKey !== 'YOUR_FIREBASE_API_KEY' &&
+                      _rawCfg.apiKey.length > 10)
+                     ? _rawCfg : null;
 
 /* ── VARIABILI GLOBALI (usate da storage.js e app.js) ───── */
 var firebaseReady = false;

--- a/index.html
+++ b/index.html
@@ -25,15 +25,12 @@
   <link rel="stylesheet" href="components.css">
   <link rel="stylesheet" href="utils.css">
 
-  <!-- Firebase SDK via URL riservate Firebase Hosting.
-       /__/firebase/init.js inietta automaticamente la config del progetto
-       ed esegue firebase.initializeApp() — nessun config.js necessario in produzione.
-       Fallback: se config.js esiste localmente (sviluppo), firebase-config.js usa
-       la guard firebase.apps.length===0 per non inizializzare due volte. -->
-  <script src="/__/firebase/10.14.1/firebase-app-compat.js"></script>
-  <script src="/__/firebase/10.14.1/firebase-auth-compat.js"></script>
-  <script src="/__/firebase/10.14.1/firebase-database-compat.js"></script>
-  <script src="/__/firebase/init.js"></script>
+  <!-- Firebase SDK via CDN pubblico (funziona su qualsiasi hosting, incluso GitHub Pages).
+       La config viene iniettata da config.js (generato da GitHub Actions via secrets).
+       Fallback locale: copia config.example.js → config.js con le tue chiavi. -->
+  <script src="https://www.gstatic.com/firebasejs/10.14.1/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.14.1/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/10.14.1/firebase-database-compat.js"></script>
 </head>
 
 <body>

--- a/sw.js
+++ b/sw.js
@@ -3,36 +3,41 @@
    Cache-first per asset statici, network-first per dati.
 ============================================================ */
 
-var CACHE_NAME = 'nutriplan-v2';
+var CACHE_NAME = 'nutriplan-v3';
+
+/* Calcola il base path dinamicamente: funziona sia a root (/sw.js)
+   che in sottocartella (/Nutriplan_/sw.js → base '/Nutriplan_') */
+var BASE_PATH = self.location.pathname.replace(/\/sw\.js$/, '');
+
 var STATIC_ASSETS = [
-  '/',
-  '/index.html',
-  '/manifest.json',
-  '/icon.svg',
-  '/base.css',
-  '/nav.css',
-  '/layout.css',
-  '/components.css',
-  '/utils.css',
-  '/style.css',
-  '/app.js',
-  '/data.js',
-  '/storage.js',
-  '/piano.js',
-  '/piano_alimentare.js',
-  '/dispensa.js',
-  '/ricette.js',
-  '/ricette_custom.js',
-  '/spesa.js',
-  '/storico.js',
-  '/statistiche.js',
-  '/profilo.js',
-  '/pdf.js',
-  '/tutorial.js',
-  '/onboarding.js',
-  '/gemini.js',
-  '/firebase-config.js',
-  '/config.js'
+  BASE_PATH + '/',
+  BASE_PATH + '/index.html',
+  BASE_PATH + '/manifest.json',
+  BASE_PATH + '/icon.svg',
+  BASE_PATH + '/base.css',
+  BASE_PATH + '/nav.css',
+  BASE_PATH + '/layout.css',
+  BASE_PATH + '/components.css',
+  BASE_PATH + '/utils.css',
+  BASE_PATH + '/style.css',
+  BASE_PATH + '/app.js',
+  BASE_PATH + '/data.js',
+  BASE_PATH + '/storage.js',
+  BASE_PATH + '/piano.js',
+  BASE_PATH + '/piano_alimentare.js',
+  BASE_PATH + '/dispensa.js',
+  BASE_PATH + '/ricette.js',
+  BASE_PATH + '/ricette_custom.js',
+  BASE_PATH + '/spesa.js',
+  BASE_PATH + '/storico.js',
+  BASE_PATH + '/statistiche.js',
+  BASE_PATH + '/profilo.js',
+  BASE_PATH + '/pdf.js',
+  BASE_PATH + '/tutorial.js',
+  BASE_PATH + '/onboarding.js',
+  BASE_PATH + '/gemini.js',
+  BASE_PATH + '/firebase-config.js'
+  /* config.js escluso: generato a runtime da GitHub Actions, non sempre presente */
 ];
 
 self.addEventListener('install', function(e) {
@@ -82,7 +87,7 @@ self.addEventListener('fetch', function(e) {
       }).catch(function() {
         /* Offline fallback: ritorna index.html per navigazione */
         if (e.request.headers.get('accept') && e.request.headers.get('accept').includes('text/html')) {
-          return caches.match('/index.html');
+          return caches.match(BASE_PATH + '/index.html');
         }
       });
     })


### PR DESCRIPTION
## Summary
Refactored the application to support deployment on GitHub Pages (including project pages with subdirectories) while maintaining compatibility with root-level hosting. This includes migrating from Firebase Hosting's automatic configuration to manual config injection via GitHub Actions secrets.

## Key Changes

- **Dynamic Base Path in Service Worker**: Added `BASE_PATH` calculation in `sw.js` that extracts the deployment path from `self.location.pathname`, allowing the app to work both at root (`/`) and in subdirectories (e.g., `/Nutriplan_/`). Updated all cached asset paths to use `BASE_PATH` prefix.

- **Firebase SDK Migration**: Switched from Firebase Hosting's auto-injected SDK (`/__/firebase/init.js`) to public CDN URLs (`gstatic.com`), enabling deployment on any hosting platform including GitHub Pages.

- **GitHub Actions Deployment Workflow**: Added `.github/workflows/deploy.yml` that automatically generates `config.js` from GitHub Secrets during deployment, injecting Firebase and Gemini API credentials securely without committing them to the repository.

- **Service Worker Registration**: Changed from absolute path (`/sw.js`) to relative path (`sw.js`) in `app.js` to support subdirectory deployments.

- **Config Validation**: Enhanced `firebase-config.js` with validation logic to detect empty or placeholder API keys, preventing initialization failures when secrets are not configured.

- **Cache Version Bump**: Updated `CACHE_NAME` from `nutriplan-v2` to `nutriplan-v3` to invalidate old caches.

- **Excluded Runtime-Generated Files**: Removed `config.js` from the static assets list in `sw.js` with a comment explaining it's generated at runtime by GitHub Actions.

## Implementation Details

The solution maintains backward compatibility with local development (via `config.example.js`) while enabling secure CI/CD deployment. The dynamic base path calculation uses a regex pattern that safely handles both root and subdirectory deployments without requiring build-time configuration changes.

https://claude.ai/code/session_01AXR8HeCjjFWnRQLugP6Aav