### PR TITLE
Update Gemini API model from 2.0-flash to 2.5-flash

### DIFF
--- a/gemini.js
+++ b/gemini.js
@@ -16,7 +16,7 @@ function _geminiCall(prompt, callback) {
     return;
   }
 
-  var url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=' + encodeURIComponent(apiKey);
+  var url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=' + encodeURIComponent(apiKey);
 
   var body = JSON.stringify({
     contents: [{ parts: [{ text: prompt }] }],


### PR DESCRIPTION
## Summary
Updates the Gemini API model version used for content generation from `gemini-2.0-flash` to `gemini-2.5-flash`.

## Changes
- Updated the model identifier in the API endpoint URL from `gemini-2.0-flash` to `gemini-2.5-flash`
- This change affects all generative content requests made through the `_geminiCall` function

## Details
The API endpoint URL in `gemini.js` has been updated to use the newer Gemini 2.5 Flash model, which may provide improved performance, capabilities, or cost efficiency compared to the previous 2.0 version.

https://claude.ai/code/session_01XosJh6sxnTgbdALcFjHbEN