### PR TITLE
Update service worker cache version and refactor gemini.js handling

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
    Cache-first per asset statici, network-first per dati.
 ============================================================ */
 
-var CACHE_NAME = 'nutriplan-v4';
+var CACHE_NAME = 'nutriplan-v5';
 
 /* Calcola il base path dinamicamente: funziona sia a root (/sw.js)
    che in sottocartella (/Nutriplan_/sw.js → base '/Nutriplan_') */
@@ -35,7 +35,6 @@ var STATIC_ASSETS = [
   BASE_PATH + '/pdf.js',
   BASE_PATH + '/tutorial.js',
   BASE_PATH + '/onboarding.js',
-  BASE_PATH + '/gemini.js',
   BASE_PATH + '/firebase-config.js'
   /* config.js escluso: generato a runtime da GitHub Actions, non sempre presente */
 ];
@@ -67,11 +66,11 @@ self.addEventListener('fetch', function(e) {
   if (e.request.method !== 'GET') return;
   var url = e.request.url;
 
-  /* Bypassa: Firebase, Gemini, Google Fonts, CDN, blob: */
+  /* Bypassa: Firebase, Gemini, Google Fonts, CDN, blob:, gemini.js (sempre rete) */
   if (url.includes('firebase') || url.includes('generativelanguage') ||
       url.includes('fonts.googleapis') || url.includes('fonts.gstatic') ||
       url.includes('unpkg.com') || url.startsWith('blob:') ||
-      url.includes('gstatic.com/firebasejs')) {
+      url.includes('gstatic.com/firebasejs') || url.includes('/gemini.js')) {
     return;
   }
 


### PR DESCRIPTION
## Summary
Updated the service worker configuration to version 5 and refactored how the `gemini.js` file is handled in the caching strategy. The file is now excluded from static asset caching and instead always fetched from the network.

## Key Changes
- Bumped `CACHE_NAME` from `nutriplan-v4` to `nutriplan-v5` to invalidate the previous cache
- Removed `gemini.js` from the `STATIC_ASSETS` array to prevent it from being cached during service worker installation
- Added `gemini.js` to the network bypass list in the fetch event handler to ensure it's always fetched fresh from the network
- Updated the bypass comment to clarify that `gemini.js` is always fetched from the network

## Implementation Details
This change ensures that the Gemini integration file is always retrieved from the network rather than served from cache, allowing for real-time updates without requiring users to manually clear their cache. The static asset removal combined with the explicit network bypass provides a clear, maintainable approach to handling this dynamic dependency.

https://claude.ai/code/session_01NLkirhXWKaRfJLAvifptMe