### PR TITLE
fix: rimuovi mealPlan, unica fonte di verità pianoAlimentare + fix pe…

### DIFF
--- a/app.js
+++ b/app.js
@@ -766,11 +766,11 @@ function updateAllUI() {
 ══════════════════════════════════════════════════ */
 function resetDay() {
   if (!confirm('Vuoi resettare il piano di oggi?')) return;
-  if (typeof mealPlan !== 'undefined') {
+  if (typeof pianoAlimentare !== 'undefined') {
     ['colazione','spuntino','pranzo','merenda','cena'].forEach(function(mk) {
-      if (mealPlan[mk]) {
-        ['principale','contorno','frutta','extra'].forEach(function(cat) {
-          mealPlan[mk][cat] = [];
+      if (pianoAlimentare[mk]) {
+        Object.keys(pianoAlimentare[mk]).forEach(function(cat) {
+          pianoAlimentare[mk][cat] = [];
         });
       }
     });
@@ -1035,7 +1035,7 @@ function pushUndo(description) {
   _undoStack.push({
     desc:        description,
     pantryItems: JSON.parse(JSON.stringify(typeof pantryItems !== 'undefined' ? pantryItems : {})),
-    mealPlan:    JSON.parse(JSON.stringify(typeof mealPlan    !== 'undefined' ? mealPlan    : {})),
+    pianoAlimentare: JSON.parse(JSON.stringify(typeof pianoAlimentare !== 'undefined' ? pianoAlimentare : {})),
     appHistory:  JSON.parse(JSON.stringify(typeof appHistory  !== 'undefined' ? appHistory  : {})),
     spesaItems:  JSON.parse(JSON.stringify(typeof spesaItems  !== 'undefined' ? spesaItems  : []))
   });
@@ -1047,7 +1047,7 @@ function performUndo() {
   var s = _undoStack.pop();
   if (!s) { showToast('Nessuna azione da annullare', 'info'); return; }
   pantryItems = s.pantryItems;
-  mealPlan    = s.mealPlan;
+  pianoAlimentare = s.pianoAlimentare;
   appHistory  = s.appHistory;
   spesaItems  = s.spesaItems;
   if (typeof saveData === 'function') saveData();

--- a/dispensa.js
+++ b/dispensa.js
@@ -153,8 +153,8 @@ function getAllPantryItems() {
   /* 1. Dal piano */
   var mealKeys = ['colazione', 'spuntino', 'pranzo', 'merenda', 'cena'];
   mealKeys.forEach(function(mk) {
-    var mp = (typeof mealPlan !== 'undefined' && mealPlan && mealPlan[mk]) ? mealPlan[mk] : {};
-    ['principale', 'contorno', 'frutta', 'extra'].forEach(function(cat) {
+    var mp = (typeof pianoAlimentare !== 'undefined' && pianoAlimentare && pianoAlimentare[mk]) ? pianoAlimentare[mk] : {};
+    Object.keys(mp).forEach(function(cat) {
       var arr = mp[cat];
       if (!Array.isArray(arr)) return;
       arr.forEach(function(item) {

--- a/onboarding.js
+++ b/onboarding.js
@@ -54,10 +54,10 @@ function checkOnboarding() {
 
   /* Se il piano ha già qualcosa → skip onboarding */
   var hasPlan = false;
-  if (typeof mealPlan !== 'undefined' && mealPlan) {
+  if (typeof pianoAlimentare !== 'undefined' && pianoAlimentare) {
     OB_MEAL_ORDER.forEach(function(mk) {
-      var m = mealPlan[mk] || {};
-      ['principale','contorno','frutta','extra'].forEach(function(cat) {
+      var m = pianoAlimentare[mk] || {};
+      Object.keys(m).forEach(function(cat) {
         if (Array.isArray(m[cat]) && m[cat].length > 0) hasPlan = true;
       });
     });
@@ -270,18 +270,18 @@ function saveOnboardingPlan() {
       showToast('💡 Piano salvato con pochi alimenti — puoi aggiungerne altri in seguito', 'info');
   }
 
-  /* Build mealPlan */
-  if (typeof mealPlan === 'undefined') window.mealPlan = {};
+  /* Build pianoAlimentare */
+  if (typeof pianoAlimentare === 'undefined') window.pianoAlimentare = {};
   var catMap = ['principale', 'contorno', 'frutta', 'extra'];
 
   OB_MEAL_ORDER.forEach(function(mk) {
     var foods = _obData[mk] || [];
     if (!foods.length) return;
-    if (!mealPlan[mk]) mealPlan[mk] = { principale:[], contorno:[], frutta:[], extra:[] };
+    if (!pianoAlimentare[mk]) pianoAlimentare[mk] = { principale:[], contorno:[], frutta:[], extra:[] };
     foods.forEach(function(name, idx) {
       var cat = catMap[Math.min(Math.floor(idx / 2), catMap.length - 1)];
-      if (!Array.isArray(mealPlan[mk][cat])) mealPlan[mk][cat] = [];
-      mealPlan[mk][cat].push({ name: name, quantity: null, unit: 'porzione' });
+      if (!Array.isArray(pianoAlimentare[mk][cat])) pianoAlimentare[mk][cat] = [];
+      pianoAlimentare[mk][cat].push({ name: name, quantity: null, unit: 'porzione' });
     });
   });
 

--- a/pdf.js
+++ b/pdf.js
@@ -9,9 +9,9 @@ function exportPDF() {
   /* ── Piano alimentare ── */
   var pianoRows = '';
   MEALS_ORDER.forEach(function(meal) {
-    var plan  = (mealPlan && mealPlan[meal]) ? mealPlan[meal] : {};
+    var plan  = (pianoAlimentare && pianoAlimentare[meal]) ? pianoAlimentare[meal] : {};
     var allItems = [];
-    ['principale','contorno','frutta','extra'].forEach(function(cat){
+    Object.keys(plan).forEach(function(cat){
       if (Array.isArray(plan[cat])) plan[cat].forEach(function(i){ if(i&&i.name) allItems.push(i); });
     });
     if (!allItems.length) return;

--- a/piano.js
+++ b/piano.js
@@ -49,13 +49,13 @@ function ensureDefaultPlan() {
   /* Non ripristinare i default se l'utente ha esplicitamente cancellato
      tutti i dati — il piano deve restare vuoto */
   if (localStorage.getItem('nutriplan_cleared') === '1') return;
-  var isEmpty = !mealPlan || !Object.keys(mealPlan).some(function(mk){
-    var m = mealPlan[mk] || {};
+  var isEmpty = !pianoAlimentare || !Object.keys(pianoAlimentare).some(function(mk){
+    var m = pianoAlimentare[mk] || {};
     return ['principale','contorno','frutta','extra'].some(function(cat){
       return Array.isArray(m[cat]) && m[cat].length > 0;
     });
   });
-  if (isEmpty) mealPlan = JSON.parse(JSON.stringify(defaultMealPlan));
+  if (isEmpty) pianoAlimentare = JSON.parse(JSON.stringify(defaultMealPlan));
 }
 
 /* ── PROGRESS ── */
@@ -87,20 +87,11 @@ function renderMealProgress() {
 
 /* ── MEAL ITEMS ── */
 function getMealItems(meal) {
-  var plan = (mealPlan && mealPlan[meal]) ? mealPlan[meal] : {};
-  var out  = [];
-  ['principale','contorno','frutta','extra'].forEach(function(cat){
-    var arr = plan[cat];
-    if (Array.isArray(arr)) arr.forEach(function(i){
-      if (i && i.name) out.push(Object.assign({}, i, { _cat: cat }));
-    });
-  });
-  /* Fallback: leggi da pianoAlimentare se mealPlan per questo pasto è vuoto */
-  if (!out.length && typeof pianoAlimentare !== 'undefined' && pianoAlimentare && pianoAlimentare[meal]) {
+  var out = [];
+  if (pianoAlimentare && pianoAlimentare[meal]) {
     Object.keys(pianoAlimentare[meal]).forEach(function(cat) {
       var arr = pianoAlimentare[meal][cat];
-      if (!Array.isArray(arr)) return;
-      arr.forEach(function(i) {
+      if (Array.isArray(arr)) arr.forEach(function(i) {
         if (i && i.name) out.push(Object.assign({}, i, { _cat: cat }));
       });
     });
@@ -317,10 +308,10 @@ function openSubstituteModal(name) {
   seenPlan[name] = true;
   inFridge.forEach(function(k){ seenPlan[k] = true; });
 
-  if (typeof mealPlan !== 'undefined' && mealPlan) {
+  if (typeof pianoAlimentare !== 'undefined' && pianoAlimentare) {
     ['colazione','spuntino','pranzo','merenda','cena'].forEach(function(mk){
-      var mp = mealPlan[mk] || {};
-      ['principale','contorno','frutta','extra'].forEach(function(cat){
+      var mp = pianoAlimentare[mk] || {};
+      Object.keys(mp).forEach(function(cat){
         var arr = mp[cat];
         if (!Array.isArray(arr)) return;
         arr.forEach(function(item){

--- a/profilo.js
+++ b/profilo.js
@@ -201,7 +201,7 @@ function buildProfiloPianoSection() {
   if (!profiloEditMode) {
     /* ── VISTA LETTURA ── */
     var cards = meals.map(function(m){
-      var plan  = (mealPlan && mealPlan[m.key]) ? mealPlan[m.key] : {};
+      var plan  = (pianoAlimentare && pianoAlimentare[m.key]) ? pianoAlimentare[m.key] : {};
       var items = [];
       ['principale','contorno','frutta','extra'].forEach(function(cat){
         if (Array.isArray(plan[cat])) plan[cat].forEach(function(i){
@@ -247,7 +247,7 @@ function buildProfiloPianoSection() {
   }
 
   /* ── VISTA MODIFICA ── */
-  var data   = editMealPlanData || JSON.parse(JSON.stringify(mealPlan||{}));
+  var data   = editMealPlanData || JSON.parse(JSON.stringify(pianoAlimentare||{}));
   var fields = meals.map(function(m){
     var plan  = data[m.key] || {};
     var items = [];
@@ -324,7 +324,7 @@ function toggleProfiloPasto(header) {
 /* ── EDIT PIANO ── */
 function startEditPiano() {
   profiloEditMode  = true;
-  editMealPlanData = JSON.parse(JSON.stringify(mealPlan||{}));
+  editMealPlanData = JSON.parse(JSON.stringify(pianoAlimentare||{}));
   renderProfilo();
 }
 
@@ -387,7 +387,14 @@ function saveEditPiano() {
     });
   });
 
-  mealPlan        = newPlan;
+  /* Fondi il piano editato in pianoAlimentare, preservando le categorie nutrizionali extra */
+  if (!pianoAlimentare || typeof pianoAlimentare !== 'object') pianoAlimentare = {};
+  ['colazione','spuntino','pranzo','merenda','cena'].forEach(function(mk) {
+    if (!pianoAlimentare[mk] || typeof pianoAlimentare[mk] !== 'object') pianoAlimentare[mk] = {};
+    ['principale','contorno','frutta','extra'].forEach(function(cat) {
+      pianoAlimentare[mk][cat] = newPlan[mk] ? (newPlan[mk][cat] || []) : [];
+    });
+  });
   profiloEditMode = false;
   editMealPlanData= null;
   saveData();
@@ -497,7 +504,6 @@ function executeDeleteAllData() {
 
   /* Azzeramento locale */
   if (typeof pantryItems          !== 'undefined') pantryItems          = {};
-  if (typeof mealPlan             !== 'undefined') mealPlan             = {};
   if (typeof appHistory           !== 'undefined') appHistory           = {};
   if (typeof spesaItems           !== 'undefined') spesaItems           = [];
   if (typeof pianoAlimentare      !== 'undefined') pianoAlimentare      = {};

--- a/ricette.js
+++ b/ricette.js
@@ -137,22 +137,6 @@ function getPianoAlimentareIngNames() {
       });
     });
   });
-  /* Fallback: usa anche mealPlan se pianoAlimentare è vuoto */
-  if (!names.length && typeof mealPlan !== 'undefined' && mealPlan) {
-    Object.keys(mealPlan).forEach(function(mk) {
-      var m = mealPlan[mk];
-      if (!m) return;
-      ['principale','contorno','frutta','extra'].forEach(function(cat) {
-        if (!Array.isArray(m[cat])) return;
-        m[cat].forEach(function(it) {
-          if (it && it.name && !seen[it.name]) {
-            seen[it.name] = true;
-            names.push(it.name.toLowerCase().trim());
-          }
-        });
-      });
-    });
-  }
   return names;
 }
 
@@ -684,15 +668,15 @@ function applyRecipeToMeal() {
   if (!currentRecipeName) return;
   var r = findRicetta(currentRecipeName); if (!r) return;
   var pasto = Array.isArray(r.pasto)?(r.pasto[0]||'pranzo'):(r.pasto||'pranzo');
-  if (!mealPlan[pasto]) mealPlan[pasto]={principale:[],contorno:[],frutta:[],extra:[]};
-  if (!Array.isArray(mealPlan[pasto].principale)) mealPlan[pasto].principale=[];
+  if (!pianoAlimentare[pasto]) pianoAlimentare[pasto]={principale:[],contorno:[],frutta:[],extra:[]};
+  if (!Array.isArray(pianoAlimentare[pasto].principale)) pianoAlimentare[pasto].principale=[];
   var ings=Array.isArray(r.ingredienti)?r.ingredienti:[], added=0;
   ings.forEach(function(ing){
     var nm=safeStr(ing.name||ing.nome).trim(); if(!nm) return;
-    var exists=mealPlan[pasto].principale.some(function(i){
+    var exists=pianoAlimentare[pasto].principale.some(function(i){
       return safeStr(i.name).toLowerCase()===nm.toLowerCase();
     });
-    if (!exists){ mealPlan[pasto].principale.push({name:nm,quantity:ing.quantity||null,unit:ing.unit||'g'}); added++; }
+    if (!exists){ pianoAlimentare[pasto].principale.push({name:nm,quantity:ing.quantity||null,unit:ing.unit||'g'}); added++; }
   });
   saveData(); closeRecipeModal();
   if (typeof renderMealPlan==='function') renderMealPlan();

--- a/spesa.js
+++ b/spesa.js
@@ -315,12 +315,9 @@ function generateShoppingList() {
   }
 
   ['colazione','spuntino','pranzo','merenda','cena'].forEach(function(mk){
-    /* Legge prima da mealPlan, poi come fallback da pianoAlimentare */
-    var planMeal = (typeof mealPlan !== 'undefined' && mealPlan && mealPlan[mk])
-                   ? mealPlan[mk]
-                   : ((typeof pianoAlimentare !== 'undefined' && pianoAlimentare && pianoAlimentare[mk])
-                      ? pianoAlimentare[mk] : {});
-    ['principale','contorno','frutta','extra'].forEach(function(cat){
+    var planMeal = (typeof pianoAlimentare !== 'undefined' && pianoAlimentare && pianoAlimentare[mk])
+                   ? pianoAlimentare[mk] : {};
+    Object.keys(planMeal).forEach(function(cat){
       var arr = planMeal[cat];
       if (!Array.isArray(arr)) return;
       arr.forEach(function(item){


### PR DESCRIPTION
…rdita piano al login

- Elimina la variabile globale `mealPlan` da tutto il codebase (10 file, ~45 ref)
- Tutte le letture/scritture del piano ora usano solo `pianoAlimentare`
- Fix bug critico in `loadFromCloud()`: al primo login con Firebase vuoto, i dati locali dell'utente venivano azzerati incondizionatamente e poi riscritti vuoti su Firebase causando perdita irreversibile del piano. Ora il reset avviene solo se l'utente ha esplicitamente cancellato i dati (flag `nutriplan_cleared`), preservando il piano costruito offline.
- `getMealItems()` in piano.js ora legge tutti i keys da `pianoAlimentare` senza logica primario/fallback ridondante
- `saveEditPiano()` in profilo.js fonde il piano editato in `pianoAlimentare` preservando le categorie nutrizionali extra
- `resetDay()` azzera tutte le categorie dinamicamente con Object.keys
- spesa.js, dispensa.js, pdf.js aggiornati per leggere da `pianoAlimentare`

https://claude.ai/code/session_019BgedZRncqZ3Qh5j7rA6zc